### PR TITLE
Updated Window Moving Handler

### DIFF
--- a/src/Components/DraggablePanel.cs
+++ b/src/Components/DraggablePanel.cs
@@ -1,26 +1,31 @@
+using GodAmp.Utils;
 using Godot;
 
 namespace GodAmp.Components;
 
-public partial class DraggablePanel : Panel
+public partial class DraggablePanel : Control
 {
-	[Signal] public delegate void OnDraggablePanelInputEventHandler(); 
-	
-	public override void _Input(InputEvent @event)
+	private bool _following = false;
+
+	private Vector2I _mouseOffset;
+
+	public override void _Ready()
 	{
-		if (!Visible)
-			return;
-		
-		if (@event is InputEventMouseButton mouseEvent)
-		{
-			if (mouseEvent.Pressed && GetGlobalRect().HasPoint(mouseEvent.GlobalPosition))
-			{
-				EmitSignal(SignalName.OnDraggablePanelInput, @event);
-			}
-			else if (!mouseEvent.Pressed)
-			{
-				EmitSignal(SignalName.OnDraggablePanelInput, @event);
-			}
-		}
+		GuiInput += OnGuiInput;
+	}
+
+	private void OnGuiInput(InputEvent inputEvent)
+	{
+		if (inputEvent is not InputEventMouseButton { ButtonIndex: MouseButton.Left }) return;
+		_following = !_following;
+		MouseDefaultCursorShape = _following ? CursorShape.Move : CursorShape.Arrow;
+		_mouseOffset = GetTree().Root.GetMousePosition().ToVector2I();
+	}
+
+	public override void _Process(double delta)
+	{
+		if (!_following) return;
+
+		GetTree().Root.Position = DisplayServer.MouseGetPosition() - _mouseOffset;
 	}
 }

--- a/src/Components/WindowPanelContainer.cs
+++ b/src/Components/WindowPanelContainer.cs
@@ -7,40 +7,9 @@ public partial class WindowPanelContainer : PanelContainer
 	[Signal] public delegate void CloseButtonClickedEventHandler();
 	
 	[Export] public Control Contents;
-	[Export] public bool MoveGlobalWindow = false;
 
 	private bool _minimized = false;
 	private bool _closed = false;
-		
-	private bool _dragging = false;
-	private Vector2 _dragOffset = Vector2.Zero;
-	private Input.MouseModeEnum _previousMouseMode;
-	
-	public override void _Input(InputEvent @event)
-	{
-		if (_dragging && MoveGlobalWindow && @event is InputEventMouseMotion motionEvent)
-		{
-			// Calculate the window scale factor by comparing current size to content scale
-			float scaleFactorX = GetWindow().Size.X / GetViewport().GetVisibleRect().Size.X;
-			float scaleFactorY = GetWindow().Size.Y / GetViewport().GetVisibleRect().Size.Y;
-			float scaleFactor = (scaleFactorX + scaleFactorY) / 2.0f;
-			
-			Vector2 scaledMotion = motionEvent.Relative * scaleFactor;
-			
-			// Apply the scaled movement to the window position
-			Vector2I windowPosition = DisplayServer.WindowGetPosition();
-			windowPosition += new Vector2I((int)scaledMotion.X, (int)scaledMotion.Y);
-			DisplayServer.WindowSetPosition(windowPosition);
-		}
-	}
-
-	public override void _Process(double delta)
-	{
-		if (_dragging && !MoveGlobalWindow)
-		{
-			GlobalPosition = GetGlobalMousePosition() - _dragOffset;
-		}
-	}
 	
 	public virtual void OnCloseButtonPressed()
 	{
@@ -54,26 +23,4 @@ public partial class WindowPanelContainer : PanelContainer
 		_minimized = !_minimized;
 		Contents.Visible = !Contents.Visible;
 	}
-
-    private void OnDraggablePanelInput(InputEvent @event)
-    {
-        if (@event is InputEventMouseButton mouseEvent)
-        {
-            if (mouseEvent.ButtonIndex == MouseButton.Left)
-            {
-                if (mouseEvent.Pressed)
-                {
-                    _dragging = true;
-                    if (!MoveGlobalWindow)
-                    {
-                        _dragOffset = GetGlobalMousePosition() - GlobalPosition;
-                    }
-                }
-                else
-                {
-                    _dragging = false;
-                }
-            }
-        }
-    }
 }

--- a/src/Components/draggable_panel.tscn
+++ b/src/Components/draggable_panel.tscn
@@ -1,12 +1,11 @@
-[gd_scene load_steps=3 format=3 uid="uid://btjg3gj5nwcqw"]
+[gd_scene load_steps=2 format=3 uid="uid://btjg3gj5nwcqw"]
 
 [ext_resource type="Script" uid="uid://cqqxnfydcmiuw" path="res://src/Components/DraggablePanel.cs" id="1_7rr22"]
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_y504q"]
-
-[node name="DraggablePanel" type="Panel"]
+[node name="DraggablePanel" type="Control"]
 custom_minimum_size = Vector2(0, 28)
+layout_mode = 3
+anchors_preset = 0
+offset_bottom = 28.0
 size_flags_vertical = 0
-mouse_filter = 2
-theme_override_styles/panel = SubResource("StyleBoxEmpty_y504q")
 script = ExtResource("1_7rr22")

--- a/src/Controls/Equalizer/equalizer.tscn
+++ b/src/Controls/Equalizer/equalizer.tscn
@@ -514,8 +514,19 @@ text = "16K"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="DraggablePanel" parent="." instance=ExtResource("7_r0ulg")]
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
+size_flags_vertical = 0
+mouse_filter = 2
+
+[node name="DraggablePanel" parent="HBoxContainer" instance=ExtResource("7_r0ulg")]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Control" type="Control" parent="HBoxContainer"]
+custom_minimum_size = Vector2(28, 0)
+layout_mode = 2
+mouse_filter = 2
 
 [connection signal="pressed" from="HeaderContainer/HBoxContainer/MinimizeButton" to="." method="OnMinimizeButtonPressed"]
 [connection signal="pressed" from="HeaderContainer/HBoxContainer/CloseButton" to="." method="OnCloseButtonPressed"]
@@ -531,4 +542,3 @@ layout_mode = 2
 [connection signal="value_changed" from="ContentContainer/MarginContainer/VBoxContainer/HBoxContainer2/VBoxContainer9/12KSlider" to="." method="On12KSliderValueChanged"]
 [connection signal="value_changed" from="ContentContainer/MarginContainer/VBoxContainer/HBoxContainer2/VBoxContainer10/14KSlider" to="." method="On14KSliderValueChanged"]
 [connection signal="value_changed" from="ContentContainer/MarginContainer/VBoxContainer/HBoxContainer2/VBoxContainer11/16KSlider" to="." method="On16KSliderValueChanged"]
-[connection signal="OnDraggablePanelInput" from="DraggablePanel" to="." method="OnDraggablePanelInput"]

--- a/src/Controls/MasterPanel/master_panel.tscn
+++ b/src/Controls/MasterPanel/master_panel.tscn
@@ -515,8 +515,19 @@ texture_normal = SubResource("AtlasTexture_1qudr")
 texture_pressed = SubResource("AtlasTexture_u5eu6")
 stretch_mode = 5
 
-[node name="DraggablePanel" parent="." instance=ExtResource("12_x5ey5")]
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
+size_flags_vertical = 0
+mouse_filter = 2
+
+[node name="DraggablePanel" parent="HBoxContainer" instance=ExtResource("12_x5ey5")]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Control" type="Control" parent="HBoxContainer"]
+custom_minimum_size = Vector2(28, 24)
+layout_mode = 2
+mouse_filter = 2
 
 [connection signal="pressed" from="HeaderContainer/HBoxContainer/MinimizeButton" to="." method="OnMinimizeButtonPressed"]
 [connection signal="pressed" from="HeaderContainer/HBoxContainer/CloseButton" to="." method="OnCloseButtonPressed"]
@@ -541,4 +552,3 @@ layout_mode = 2
 [connection signal="pressed" from="ContentContainer/MarginContainer/VBoxContainer/HBoxContainer3/HBoxContainer2/LoadTracksButton" to="." method="OnLoadTracksButtonPressed"]
 [connection signal="pressed" from="ContentContainer/MarginContainer/VBoxContainer/HBoxContainer3/HBoxContainer3/ShuffleModeButton" to="." method="OnShuffleModeButtonPressed"]
 [connection signal="pressed" from="ContentContainer/MarginContainer/VBoxContainer/HBoxContainer3/HBoxContainer3/RepeatModeButton" to="." method="OnRepeatModeButtonPressed"]
-[connection signal="OnDraggablePanelInput" from="DraggablePanel" to="." method="OnDraggablePanelInput"]

--- a/src/Controls/Playlist/playlist.tscn
+++ b/src/Controls/Playlist/playlist.tscn
@@ -134,9 +134,19 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="DraggablePanel" parent="." instance=ExtResource("7_pgi81")]
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
+size_flags_vertical = 0
+mouse_filter = 2
+
+[node name="DraggablePanel" parent="HBoxContainer" instance=ExtResource("7_pgi81")]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Control" type="Control" parent="HBoxContainer"]
+custom_minimum_size = Vector2(28, 0)
+layout_mode = 2
+mouse_filter = 2
 
 [connection signal="pressed" from="HeaderContainer/HBoxContainer/MinimizeButton" to="." method="OnMinimizeButtonPressed"]
 [connection signal="pressed" from="HeaderContainer/HBoxContainer/CloseButton" to="." method="OnCloseButtonPressed"]
-[connection signal="OnDraggablePanelInput" from="DraggablePanel" to="." method="OnDraggablePanelInput"]

--- a/src/Utils/ExtensionMethods.cs
+++ b/src/Utils/ExtensionMethods.cs
@@ -1,0 +1,12 @@
+using Godot;
+
+namespace GodAmp.Utils;
+
+public static class ExtensionMethods
+{
+    public static Vector2I ToVector2I(this Vector2 vector)
+    {
+        var v = vector.Floor();
+        return new Vector2I((int)v.X, (int)v.Y);
+    }
+}

--- a/src/Utils/ExtensionMethods.cs.uid
+++ b/src/Utils/ExtensionMethods.cs.uid
@@ -1,0 +1,1 @@
+uid://nmivlvtbjtc0

--- a/src/Visualizer/visualizer.tscn
+++ b/src/Visualizer/visualizer.tscn
@@ -121,4 +121,3 @@ layout_mode = 2
 
 [connection signal="pressed" from="HeaderContainer/HBoxContainer/MinimizeButton" to="." method="OnMinimizeButtonPressed"]
 [connection signal="pressed" from="HeaderContainer/HBoxContainer/CloseButton" to="." method="OnCloseButtonPressed"]
-[connection signal="OnDraggablePanelInput" from="DraggablePanel" to="." method="OnDraggablePanelInput"]


### PR DESCRIPTION
Updated Window Moving behavior to use DraggablePanel to allow moving the full window from within the DraggablePanel, instead of the WindowPanelContainer.  Fixes issue where Moving the window would jitter, and not move properly with the window, due to multiple signal execution, causing jitter to occur, and offset to constantly be set.